### PR TITLE
Autoload text_sensor to fix compilation

### DIFF
--- a/components/telnet_server/__init__.py
+++ b/components/telnet_server/__init__.py
@@ -13,7 +13,7 @@ CONF_VERBOSE = "verbose"
 CONF_DISCONNECT_DELAY = "disconnect_delay"
 
 DEPENDENCIES = ["network"]
-AUTO_LOAD = ["async_tcp"]
+AUTO_LOAD = ["async_tcp", "sensor", "text_sensor"]
 
 telnet_ns = cg.esphome_ns.namespace("telnet_server")
 TelnetServer = telnet_ns.class_("TelnetServer", cg.Component)


### PR DESCRIPTION
Newer versions of ESPHome won't have `text_sensor.h` available, it needs to be autoloaded like the other components.