### PR TITLE
Removed extra TELNET_SERVER_VERBOSE_LOGGING define

### DIFF
--- a/components/telnet_server/__init__.py
+++ b/components/telnet_server/__init__.py
@@ -9,7 +9,6 @@ from esphome.const import (
 # ToDo: Max number of clients
 CONF_CLIENT_COUNT = "client_count"
 CONF_CLIENT_IPS = "client_ips"
-CONF_VERBOSE = "verbose"
 CONF_DISCONNECT_DELAY = "disconnect_delay"
 
 DEPENDENCIES = ["network"]
@@ -27,7 +26,6 @@ CONFIG_SCHEMA = cv.Schema(
             accuracy_decimals=0,
         ),
         cv.Optional(CONF_CLIENT_IPS): text_sensor.text_sensor_schema(),
-        cv.Optional(CONF_VERBOSE, default=False): cv.boolean,
         cv.Optional(
             CONF_DISCONNECT_DELAY, default="2500ms"
         ): cv.positive_time_period_milliseconds,
@@ -48,6 +46,3 @@ async def to_code(config):
         cg.add(var.set_client_ip_text_sensor(sens))
 
     cg.add(var.set_disconnect_delay(config[CONF_DISCONNECT_DELAY].total_milliseconds))
-
-    if config.get(CONF_VERBOSE):
-        cg.add_define("TELNET_SERVER_VERBOSE_LOGGING")

--- a/components/telnet_server/telnet_server.cpp
+++ b/components/telnet_server/telnet_server.cpp
@@ -70,12 +70,6 @@ void TelnetServer::readSerial() {
       uint16_t lineStartIdx = char_idx;
       int len = Serial.readBytesUntil('\n', &buffer[char_idx], (MAXLINELENGTH - char_idx));
 
-      // Add terminator for Verbose logging:
-      buffer[char_idx + len] = '\0';
-#ifdef TELNET_SERVER_VERBOSE_LOGGING
-      ESP_LOGV(TAG, " %s", &buffer[lineStartIdx]);
-#endif
-
       // Add the newline for TelNet
       char_idx += len;
       buffer[char_idx] = '\n';
@@ -83,7 +77,7 @@ void TelnetServer::readSerial() {
       char_idx++;
       len++;
 
-      // push UART data to all connected telnet clients
+      ESP_LOGV(TAG, "Pushing to telnet clients: %s", &buffer[lineStartIdx]);
       for (auto const &client : this->clients_) {
         client->tcp_client->write(&buffer[lineStartIdx], len);
       }
@@ -97,9 +91,6 @@ void TelnetServer::readSerial() {
         // Dump buffer contents
         char_idx = MIN(char_idx, MAXLINELENGTH - 1);
         buffer[char_idx] = '\0';
-#ifdef TELNET_SERVER_VERBOSE_LOGGING
-        ESP_LOGV(TAG, "\n%s", buffer);
-#endif
         // Clear buffer
         memset(buffer, 0, sizeof(buffer));
         char_idx = 0;


### PR DESCRIPTION
The example just had `VERBOSE` in the logger config, but that wasn't enough.

Because the default log level of esphome is `debug`, I think having these print when a user opts into `verbose` is probably fine, without needing an extra `verbose: true` in the config.

All other stock esphome components just depend on the logger config too.