### PR TITLE
Added dump_config() method

### DIFF
--- a/components/telnet_server/telnet_server.cpp
+++ b/components/telnet_server/telnet_server.cpp
@@ -2,6 +2,7 @@
 
 #include "telnet_server.h"
 #include "esphome/core/defines.h"
+#include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
@@ -11,7 +12,7 @@
 namespace esphome {
 namespace telnet_server {
 
-static const char *const TAG = "TELNET";
+static const char *const TAG = "telnet_server";
 
 TelnetServer::Client::Client(AsyncClient *client)
     : tcp_client{client}, identifier{client->remoteIP().toString().c_str()}, disconnected{false} {
@@ -47,6 +48,13 @@ void TelnetServer::setup() {
 
   // Ensure client sensors are updated after startup.
   clients_updated_ = true;
+}
+
+void TelnetServer::dump_config() {
+  ESP_LOGCONFIG(TAG, "Config:");
+  ESP_LOGCONFIG(TAG, "  Port: %d", this->port_);
+  LOG_SENSOR(TAG, "  Client Count Sensor", this->client_count_sensor_);
+  LOG_TEXT_SENSOR(TAG, "  Client IP Text Sensor: %s", this->client_ip_text_sensor_);
 }
 
 void TelnetServer::loop() {

--- a/components/telnet_server/telnet_server.h
+++ b/components/telnet_server/telnet_server.h
@@ -24,12 +24,11 @@ namespace telnet_server {
 
 #define MAXLINELENGTH 1280
 #define DEFAULT_MAX_CLIENTS 3
-#define TELNET_PORT 23
 
 class TelnetServer : public Component {
  public:
-  TelnetServer(const uint16_t port = TELNET_PORT) : server(port) {
-    // nothing to do here
+  TelnetServer(const uint16_t port) : server(port) {
+    this->port_ = port;
   }
 
   float get_setup_priority() const override;
@@ -40,6 +39,7 @@ class TelnetServer : public Component {
   void set_disconnect_delay(uint32_t disconnect_delay) { this->client_disconnect_delay = disconnect_delay; }
 
   void setup() override;
+  void dump_config() override;
   void loop() override;
 
   void on_shutdown() override;
@@ -66,6 +66,7 @@ class TelnetServer : public Component {
   std::map<std::string, uint32_t> client_disconnect_times{};
   std::set<std::string> last_published_values{};
   bool clients_updated_ = false;
+  uint16_t port_;
 
   uint32_t client_disconnect_delay = 5000; // ms
 


### PR DESCRIPTION
The `dump_config` method is a very common idiom for esphome component. It prints the config early in the boot sequence to help debug that the actual live config is what you expected, after yaml processing and schema stuff.

I also removed the default port of 23 in the cpp code because it was already defaulting to 23 in the python code.