### PR TITLE
Added Write support and bring your own uart

### DIFF
--- a/components/telnet_server/__init__.py
+++ b/components/telnet_server/__init__.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import sensor, text_sensor
+from esphome.core import ID
+from esphome.components import sensor, text_sensor, uart
 from esphome.const import (
     CONF_ID,
     CONF_PORT,
@@ -11,9 +12,12 @@ CONF_CLIENT_COUNT = "client_count"
 CONF_CLIENT_IPS = "client_ips"
 CONF_VERBOSE = "verbose"
 CONF_DISCONNECT_DELAY = "disconnect_delay"
+CONF_UARTID = "uart_id"
 
 DEPENDENCIES = ["network"]
-AUTO_LOAD = ["async_tcp", "sensor", "text_sensor"]
+AUTO_LOAD = ["async_tcp", "sensor", "text_sensor", "uart"]
+
+MULTI_CONF = True
 
 telnet_ns = cg.esphome_ns.namespace("telnet_server")
 TelnetServer = telnet_ns.class_("TelnetServer", cg.Component)
@@ -21,6 +25,7 @@ TelnetServer = telnet_ns.class_("TelnetServer", cg.Component)
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(TelnetServer),
+        cv.Required(CONF_UARTID): cv.use_id(uart.UARTComponent),
         cv.Optional(CONF_PORT, default=23): cv.port,
         cv.Optional(CONF_CLIENT_COUNT): sensor.sensor_schema(
             unit_of_measurement=" ",
@@ -48,6 +53,9 @@ async def to_code(config):
         cg.add(var.set_client_ip_text_sensor(sens))
 
     cg.add(var.set_disconnect_delay(config[CONF_DISCONNECT_DELAY].total_milliseconds))
+
+    uart_var = await cg.get_variable(config[CONF_UARTID])
+    cg.add(var.set_uart(uart_var))
 
     if config.get(CONF_VERBOSE):
         cg.add_define("TELNET_SERVER_VERBOSE_LOGGING")

--- a/components/telnet_server/telnet_server.h
+++ b/components/telnet_server/telnet_server.h
@@ -1,19 +1,17 @@
 #pragma once
 
-// Only works on Arduino framework!
-#ifdef USE_ARDUINO
-
 #ifdef ARDUINO_ARCH_ESP8266
 #include <ESPAsyncTCP.h>
 #else
 // AsyncTCP.h includes parts of freertos, which require FreeRTOS.h header to be included first
-#include <freertos/FreeRTOS.h>
+//#include <freertos/FreeRTOS.h>
 #include <AsyncTCP.h>
 #endif
 
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/uart/uart.h"
 
 #include <set>
 
@@ -29,8 +27,8 @@ namespace telnet_server {
 class TelnetServer : public Component {
  public:
   TelnetServer(const uint16_t port = TELNET_PORT) : server(port) {
-    // nothing to do here
-  }
+    this->port_ = port;
+ }
 
   float get_setup_priority() const override;
 
@@ -40,28 +38,34 @@ class TelnetServer : public Component {
   void set_disconnect_delay(uint32_t disconnect_delay) { this->client_disconnect_delay = disconnect_delay; }
 
   void setup() override;
+  void dump_config() override;
   void loop() override;
-
+  void set_uart(uart::UARTComponent *uart);
+  int readBytesUntil(uart::UARTComponent *uart, char terminator, char *buffer, int max_length);
+  
   void on_shutdown() override;
 
  protected:
   void cleanup();
 
   void readSerial();
-  void writeSerial();
+  void handleTelnetData(AsyncClient *client, void* data, size_t len);
 
   void updateClientSensors();
 
   struct Client {
-    Client(AsyncClient *client);
+    Client(AsyncClient *client, uart::UARTComponent *uart);
     ~Client() { delete this->tcp_client; }
 
+  uart::UARTComponent *uart_;
     AsyncClient *tcp_client{nullptr};
     std::string identifier{};
     bool disconnected{false};
+    void handleTelnetData(AsyncClient *client, void* data, size_t len);
   };
 
   AsyncServer server;
+  uint16_t port_;
   std::vector<std::unique_ptr<Client>> clients_{};
   std::map<std::string, uint32_t> client_disconnect_times{};
   std::set<std::string> last_published_values{};
@@ -75,9 +79,9 @@ class TelnetServer : public Component {
 
   sensor::Sensor *client_count_sensor_{nullptr};
   text_sensor::TextSensor *client_ip_text_sensor_{nullptr};
+  uart::UARTComponent *uart_{nullptr};
 };
 
 }  // namespace telnet_server
 }  // namespace esphome
 
-#endif  // USE_ARDUINO

--- a/examples/local-uart-esp32.yaml
+++ b/examples/local-uart-esp32.yaml
@@ -5,30 +5,25 @@ esphome:
   name: telnet-example
 
 esp32:
-  board: wemos_d1_mini32
-  framework:
-    type: arduino
+  board: wemos_d1_mini32y
   
 external_components:
   - source: github://RoboMagus/esphome-telnet-server
-
-wifi:
-  ssid: !secret WiFi_ssid
-  password: !secret WiFi_password
-
-# Enable Home Assistant API
-api:
-  password: !secret hass_api_password
-  encryption:
-    key: !secret api_encryption_key
-
-ota:
-  password: !secret ota_password
-    
+   
 logger:
   level: VERBOSE # this will also show lines received on Serial in Log output
 
+# See 
+# https://esphome.io/components/logger.html#default-uart-gpio-pins
+# for a breakdown of which microcontrollers use which pins
+uart:
+  id: uart_0
+  baud_rate: 115200
+  tx_pin: GPIO1
+  rx_pin: GPIO3
+
 telnet_server:
+  uart_id: uart_0
   port: 25 # defaut is 23
   client_count:
     name: "${friendly_name} client count"

--- a/examples/multi-uart-esp32.yaml
+++ b/examples/multi-uart-esp32.yaml
@@ -1,0 +1,35 @@
+substitutions:
+  friendly_name: Telnet Server
+
+esphome:
+  name: telnet-example
+
+esp32:
+  board: wemos_d1_mini32y
+  
+external_components:
+  - source: github://RoboMagus/esphome-telnet-server
+   
+logger:
+  level: VERBOSE # this will also show lines received on Serial in Log output
+
+# See 
+# https://esphome.io/components/logger.html#default-uart-gpio-pins
+# for a breakdown of which microcontrollers use which pins
+uart:
+  - id: uart_0
+    baud_rate: 115200
+    tx_pin: GPIO1
+    rx_pin: GPIO3
+  - id: uart_2
+    baud_rate: 9600
+    tx_pin: GPIO17
+    rx_pin: GPIO16
+
+telnet_server:
+  - id: standard
+    port: 23
+    uart_id: uart_0
+  - id: aux
+    port: 24
+    uart_id: uart_2

--- a/examples/secondary-uart-esp32.yaml
+++ b/examples/secondary-uart-esp32.yaml
@@ -1,0 +1,25 @@
+substitutions:
+  friendly_name: Telnet Server
+
+esphome:
+  name: telnet-example
+
+esp32:
+  board: wemos_d1_mini32y
+  
+external_components:
+  - source: github://RoboMagus/esphome-telnet-server
+   
+logger:
+  level: VERBOSE # this will also show lines received on Serial in Log output
+
+# Watch some other thing connected to the ESP32 instead of
+# the normal serial console
+uart:
+  id: uart_2
+  baud_rate: 9600
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+telnet_server:
+  port: 23
+  uart_id: uart_2


### PR DESCRIPTION
This adds a couple of things that are hard to untangle into different pull requests.

1. Adds bring your own uart

For my use case I wanted to watch the serial port from another device, _not_ the serial port that happened to be on the esp32 that esphome was using for logging (which I would like to keep). This makes the configuration a little harder for the normal case, but it is more explicit.

2. Added write support

I wanted to be able to log into my other remote device, so I added write support

3. Added multi-support

I want to be able to have multiple of these, like a serial console server. Only `MULTI_CONF = True` was required to make this happen, once the `uart_id` was ready.

This also removes the Arduino'ism for serial, as we are depending on ESPhome's uart code, which is kinda cool. Should work on any controller supported by ESPHome and any framework with this PR.

----

Note that I'll rebase this if/after the other PRs are merged.